### PR TITLE
ensure that all tags on jobs page are lower-case and are not broken

### DIFF
--- a/hyde/layout/job.j2
+++ b/hyde/layout/job.j2
@@ -34,7 +34,7 @@
             {{ resource.meta.title }}
     </h1>
     <div class="head">
-        Posted by 
+        Posted by
         <span>
             {% if resource.meta.url %}
             <a href="{{ resource.meta.url }}" target="_blank">
@@ -52,15 +52,15 @@
         </span>
         <div>
         Contract type: <span>{{ resource.meta.contract }}</span>.  Location: <span>{{ resource.meta.location }}</span>
-        </div>        
+        </div>
         {% if resource.meta.tags %}
         <div class="tags">
             <i class="i-tag"></i> Tags:
             <ul class="tags clear">
                 {% for tag in resource.meta.tags %}
                     <li>
-                        <a class="tag" href="{{ content_url('tags/'~tag~'.html') }}">
-                            {{ tag }}
+                        <a class="tag" href="{{ content_url('tags/'~tag|lower~'.html') }}">
+                            {{ tag|lower }}
                         </a>
                     </li>
                 {% endfor %}


### PR DESCRIPTION
On the home page tags are converted to lower-case. I noticed that this was not done on the job pages. This change is intended to make tag presentation more consistent.

Intended to fix #16 
