### PR TITLE
First attempt to get FaceBook OpenGraph XML working

### DIFF
--- a/hyde/layout/job.j2
+++ b/hyde/layout/job.j2
@@ -1,4 +1,14 @@
 {% extends "base.j2" %}
+{% from "macros.j2" import render_excerpt with context  %}
+
+{%  block endhead %}
+    <meta property="og:site_name" content="The Free Python Job Board"/>
+    <meta property="og:title" content="{{ resource.meta.company }}: {{ resource.meta.title }}"/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:image" content="http://pythonjobs.github.io/touch-icon-ipad-retina.png" />
+    <meta property="og:description" content="{{ resource.detail|markdown|typogrify|striptags|truncate(220) }}" />
+    <meta property="og:url" content="{{ full_url(resource.url) }}" />
+{%- endblock %}
 
 {% block main -%}
 <nav class="main">


### PR DESCRIPTION
@stestagg, @lordmauve  

This is an attempt to implement FaceBook's OpenGraph protocol. The intent is to make Facebook & LinkedIn sharing provide a more meaningful preview of the job page. Currently, they are a bit messed up.

Can you help me figure out how to get the og:description line working? This needs to be a truncated version of the item description just like we use in the sitemap & the listings page.

