### PR TITLE
Add an online Editor for creating job submissions

### DIFF
--- a/hyde/content/editor.html
+++ b/hyde/content/editor.html
@@ -1,0 +1,6 @@
+---
+extends: editor.j2
+title: Pythonjobs online submission editor
+description: The pythonjobs editor page
+default_block: unused
+---

--- a/hyde/content/map.html
+++ b/hyde/content/map.html
@@ -28,26 +28,22 @@ description: An international job board for Python roles
     left: 0; right:0;
   }
   .gm-button-style{
-    margin: 5px;
-    margin-right: -2px;
-    direction: ltr;
     overflow: hidden;
     text-align: center;
     position: relative;
-    color: rgb(0, 0, 0);
-    -webkit-user-select: none;
+    color: rgb(86, 86, 86);
+    font-family: Roboto, Arial, sans-serif;
+    user-select: none;
     font-size: 11px;
-    padding: 1px 6px;
-    border-bottom-left-radius: 2px;
-    border-top-left-radius: 2px;
-    -webkit-background-clip: padding-box;
-    border: 1px solid rgba(0, 0, 0, 0.14902);
-    -webkit-box-shadow: rgba(0, 0, 0, 0.298039) 0px 1px 4px -1px;
-    box-shadow: rgba(0, 0, 0, 0.298039) 0px 1px 4px -1px;
-    min-width: 24px;
-    font-weight: 500;
-    background-color: white;
+    background-color: rgb(255, 255, 255);
+    padding: 8px;
+    border-bottom-right-radius: 2px;
+    border-top-right-radius: 2px;
     background-clip: padding-box;
+    box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px;
+    min-width: 40px;
+    border-left: 0px;
+    margin: 10px;
   }
   .gm-button-style i{
     margin-bottom: 1px;

--- a/hyde/content/media/css/editor.css
+++ b/hyde/content/media/css/editor.css
@@ -1,0 +1,83 @@
+
+#container{
+	display: flex;
+	flex-wrap: nowrap;
+	justify-content: space-evenly;
+	align-items: stretch;
+}
+
+#editors{
+	font-family: "Source Code Pro";
+	font-size: 0.8em;
+}
+pre.sep{
+	margin-left: 4.0em;
+}
+
+h2{
+	font-weight: bold;
+}
+
+.infopanel{
+	background: white;
+    margin: 10px;
+    padding: 5px;
+    border: 1px solid #a44;
+    box-shadow: 2px 2px 10px rgba(0,0,0,0.3);
+}
+
+#editor-buttons button,
+#editor-buttons a{
+	display: inline-block;
+	padding: 3px 10px;
+	background: #005;
+	color: white;
+	border-radius: 2px;
+	box-shadow: 1px 1px 0 #55a;
+	margin-right: 1px;
+	margin-bottom: 1px;
+	vertical-align: top;
+	cursor: pointer;
+}
+#editor-buttons button:active,
+#editor-buttons a:active{
+	box-shadow: none;
+	margin-top: 1px;
+	margin-left: 1px;
+	margin-right: 0;
+	margin-bottom: 0;
+}
+
+#editor-buttons{
+	margin-bottom: 5px;
+}
+
+#editors .CodeMirror{
+	font-family: "Source Code Pro";
+	background: transparent;
+	height: auto;
+}
+#editor-column{
+	width: 50%;
+	flex-grow: 1;
+}
+#preview-column{
+	width: 50%;
+	flex-grow: 1;
+}
+
+#preview{
+	background: white;
+    margin: 10px;
+    border: 1px solid #44a;
+    box-shadow: 2px 2px 10px rgba(0,0,0,0.3);
+}
+
+#preview nav{
+	display: none;
+}
+
+#clear{
+	clear: both:
+	margin: 1px;
+}

--- a/hyde/content/media/css/site.css
+++ b/hyde/content/media/css/site.css
@@ -266,10 +266,10 @@ article.job .tags li{
 article.job .head .tag{
   display: inline-block;
   color: white;
-  background: #aaa;
-  text-shadow: 1px 1px 0 #666;
+  background: #888;
   padding: 1px 5px;
-  border-radius: 2px;
+  border-radius: 3px;
+  line-height: 1.2em;
 }
 article.job h2{
   font-weight: bold;

--- a/hyde/content/media/css/site.css
+++ b/hyde/content/media/css/site.css
@@ -56,14 +56,12 @@ body{
   padding: 0 0;
   margin: 0;
   min-height: 100%;
-  position: relative;
+  display: flex;
+  flex-direction: column;
   min-width: 350px;
 }
 
 header{
-  top: 0;
-  right: 0;
-  left: 0;
   background-color: #3a6183;
   background: url("../header-bg.jpg") no-repeat center center;
   -webkit-background-size: cover;
@@ -105,8 +103,8 @@ div.sub{
 /* Layout */
 
 #container {
+    flex-grow: 1;
     margin: 0 10px;
-    padding-bottom: 80px;
     background: url("../main-bg.jpg") no-repeat 50% 70% fixed;
     background-size: 100%;
 }
@@ -124,14 +122,10 @@ header .in,
 footer{
   background: #555;
   color: white;
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  margin:0;
   padding: 0.6em 1em;
   line-height: 1.3em;
   text-align: center;
+  margin-top: 10px;
 }
 
 footer .about{

--- a/hyde/content/media/js/job-preview.js
+++ b/hyde/content/media/js/job-preview.js
@@ -1,0 +1,275 @@
+(function() {(window.nunjucksPrecompiled = window.nunjucksPrecompiled || {})["base.j2"] = (function() {
+function root(env, context, frame, runtime, cb) {
+var lineno = null;
+var colno = null;
+var output = "";
+try {
+var parentTemplate = null;
+(parentTemplate ? function(e, c, f, r, cb) { cb(""); } : context.getBlock("main"))(env, context, frame, runtime, function(t_2,t_1) {
+if(t_2) { cb(t_2); return; }
+output += t_1;
+output += "\n";
+if(parentTemplate) {
+parentTemplate.rootRenderFunc(env, context, frame, runtime, cb);
+} else {
+cb(null, output);
+}
+});
+} catch (e) {
+  cb(runtime.handleError(e, lineno, colno));
+}
+}
+function b_main(env, context, frame, runtime, cb) {
+var lineno = null;
+var colno = null;
+var output = "";
+try {
+var frame = frame.push(true);
+output += "\n";
+cb(null, output);
+;
+} catch (e) {
+  cb(runtime.handleError(e, lineno, colno));
+}
+}
+return {
+b_main: b_main,
+root: root
+};
+
+})();
+})();
+(function() {(window.nunjucksPrecompiled = window.nunjucksPrecompiled || {})["job.j2"] = (function() {
+function root(env, context, frame, runtime, cb) {
+var lineno = null;
+var colno = null;
+var output = "";
+try {
+var parentTemplate = null;
+env.getTemplate("base.j2", true, "job.j2", false, function(t_3,t_2) {
+if(t_3) { cb(t_3); return; }
+parentTemplate = t_2
+for(var t_1 in parentTemplate.blocks) {
+context.addBlock(t_1, parentTemplate.blocks[t_1]);
+}
+output += "\n\n";
+(parentTemplate ? function(e, c, f, r, cb) { cb(""); } : context.getBlock("endhead"))(env, context, frame, runtime, function(t_5,t_4) {
+if(t_5) { cb(t_5); return; }
+output += t_4;
+output += "\n\n";
+(parentTemplate ? function(e, c, f, r, cb) { cb(""); } : context.getBlock("main"))(env, context, frame, runtime, function(t_7,t_6) {
+if(t_7) { cb(t_7); return; }
+output += t_6;
+output += "\n";
+if(parentTemplate) {
+parentTemplate.rootRenderFunc(env, context, frame, runtime, cb);
+} else {
+cb(null, output);
+}
+})})});
+} catch (e) {
+  cb(runtime.handleError(e, lineno, colno));
+}
+}
+function b_endhead(env, context, frame, runtime, cb) {
+var lineno = null;
+var colno = null;
+var output = "";
+try {
+var frame = frame.push(true);
+output += "\n    <meta property=\"og:site_name\" content=\"The Free Python Job Board\"/>\n    <meta property=\"og:title\" content=\"";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"company"), env.opts.autoescape);
+output += ": ";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"title"), env.opts.autoescape);
+output += "\"/>\n    <meta property=\"og:type\" content=\"website\"/>\n    <meta property=\"og:image\" content=\"http://pythonjobs.github.io/touch-icon-ipad-retina.png\" />\n    <meta property=\"og:description\" content=\"";
+output += runtime.suppressValue(env.getFilter("truncate").call(context, env.getFilter("striptags").call(context, env.getFilter("typogrify").call(context, env.getFilter("markdown").call(context, runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"detail")))),220), env.opts.autoescape);
+output += "\" />\n    <meta property=\"og:url\" content=\"";
+output += runtime.suppressValue((lineno = 8, colno = 46, runtime.callWrap(runtime.contextOrFrameLookup(context, frame, "full_url"), "full_url", context, [runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"url")])), env.opts.autoescape);
+output += "\" />";
+cb(null, output);
+;
+} catch (e) {
+  cb(runtime.handleError(e, lineno, colno));
+}
+}
+function b_main(env, context, frame, runtime, cb) {
+var lineno = null;
+var colno = null;
+var output = "";
+try {
+var frame = frame.push(true);
+output += "<nav class=\"main\">\n    <a class=\"backlink\" href=\"";
+output += runtime.suppressValue((lineno = 13, colno = 42, runtime.callWrap(runtime.contextOrFrameLookup(context, frame, "content_url"), "content_url", context, [runtime.memberLookup((runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"node")),"parent")),"url")])), env.opts.autoescape);
+output += "\">\n        <i class='i-list'></i>\n        Back to list\n    </a>\n    ";
+if(runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"prev_by_time")) {
+output += "\n    <a class=\"prev\"\n        title=\"";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"prev_by_time")),"meta")),"title"), env.opts.autoescape);
+output += "\"\n        href=\"";
+output += runtime.suppressValue((lineno = 20, colno = 26, runtime.callWrap(runtime.contextOrFrameLookup(context, frame, "content_url"), "content_url", context, [runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"prev_by_time")),"url")])), env.opts.autoescape);
+output += "\">\n        <i class='i-left'></i>\n        Previous Job\n    </a>\n    ";
+;
+}
+output += "\n\n    ";
+if(runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"next_by_time")) {
+output += "\n    <a class=\"next\"\n        title=\"";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"next_by_time")),"meta")),"title"), env.opts.autoescape);
+output += "\"\n        href=\"";
+output += runtime.suppressValue((lineno = 29, colno = 26, runtime.callWrap(runtime.contextOrFrameLookup(context, frame, "content_url"), "content_url", context, [runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"next_by_time")),"url")])), env.opts.autoescape);
+output += "\">\n        Next Job <i class='i-right'></i>\n    </a>\n    ";
+;
+}
+output += "\n\n    <a class=\"problem\"\n    href=\"https://github.com/pythonjobs/jobs/issues\">\n    Report a problem\n    </a>\n</nav>\n\n<article class=\"job\">\n    <h1>\n            ";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"title"), env.opts.autoescape);
+output += "\n    </h1>\n    <div class=\"head\">\n        Posted by\n        <span>\n            ";
+if(runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"url")) {
+output += "\n            <a href=\"";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"url"), env.opts.autoescape);
+output += "\" target=\"_blank\">\n            ";
+;
+}
+output += "\n                <i class=\"i-company\"></i>\n                ";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"company"), env.opts.autoescape);
+output += "\n            ";
+if(runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"url")) {
+output += "\n            </a>\n            ";
+;
+}
+output += "\n        </span>\n        on\n        <span>\n            <i class=\"i-calendar\"></i>\n            ";
+output += runtime.suppressValue((lineno = 59, colno = 43, runtime.callWrap(runtime.memberLookup((runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"created")),"strftime"), "resource[\"meta\"][\"created\"][\"strftime\"]", context, ["%a, %d %b %Y"])), env.opts.autoescape);
+output += "\n        </span>\n        <div>\n        Contract type: <span>";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"contract"), env.opts.autoescape);
+output += "</span>.  Location: <span>";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"location"), env.opts.autoescape);
+output += "</span>\n        </div>\n        ";
+if(runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"tags")) {
+output += "\n        <div class=\"tags\">\n            <i class=\"i-tag\"></i> Tags:\n            <ul class=\"tags clear\">\n                ";
+frame = frame.push();
+var t_10 = runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"tags");
+if(t_10) {t_10 = runtime.fromIterator(t_10);
+var t_9 = t_10.length;
+for(var t_8=0; t_8 < t_10.length; t_8++) {
+var t_11 = t_10[t_8];
+frame.set("tag", t_11);
+frame.set("loop.index", t_8 + 1);
+frame.set("loop.index0", t_8);
+frame.set("loop.revindex", t_9 - t_8);
+frame.set("loop.revindex0", t_9 - t_8 - 1);
+frame.set("loop.first", t_8 === 0);
+frame.set("loop.last", t_8 === t_9 - 1);
+frame.set("loop.length", t_9);
+output += "\n                    <li>\n                        <a class=\"tag\" href=\"";
+output += runtime.suppressValue((lineno = 70, colno = 57, runtime.callWrap(runtime.contextOrFrameLookup(context, frame, "content_url"), "content_url", context, ["tags/" + "" + env.getFilter("lower").call(context, t_11) + "" + ".html"])), env.opts.autoescape);
+output += "\">\n                            ";
+output += runtime.suppressValue(env.getFilter("lower").call(context, t_11), env.opts.autoescape);
+output += "\n                        </a>\n                    </li>\n                ";
+;
+}
+}
+frame = frame.pop();
+output += "\n            </ul>\n        </div>\n        ";
+;
+}
+output += "\n    </div>\n\n    <div class=\"contact\">\n        <h1>Contact</h1>\n        <div class=\"field\">\n            Name: <span>";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"contact")),"name"), env.opts.autoescape);
+output += "</span>\n        </div>\n        <div class=\"field\">\n            Email: <span><a href=\"mailto:";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"contact")),"email"), env.opts.autoescape);
+output += "?subject=pythonjobs.github.io - ";
+output += runtime.suppressValue(env.getFilter("urlencode").call(context, runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"title")), env.opts.autoescape);
+output += "\">";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"contact")),"email"), env.opts.autoescape);
+output += "</a></span>\n        </div>\n        ";
+if(runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"url")) {
+output += "\n        <div class=\"field\">\n            Website: <span><a href=\"";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"url"), env.opts.autoescape);
+output += "\">";
+output += runtime.suppressValue(runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"url"), env.opts.autoescape);
+output += "</a></span>\n        </div>\n        ";
+;
+}
+output += "\n        ";
+frame = frame.push();
+var t_14 = runtime.memberLookup((runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "resource")),"meta")),"contact");
+if(t_14) {t_14 = runtime.fromIterator(t_14);
+var t_12;
+if(runtime.isArray(t_14)) {
+var t_13 = t_14.length;
+for(t_12=0; t_12 < t_14.length; t_12++) {
+var t_15 = t_14[t_12][0];
+frame.set("[object Object]", t_14[t_12][0]);
+var t_16 = t_14[t_12][1];
+frame.set("[object Object]", t_14[t_12][1]);
+frame.set("loop.index", t_12 + 1);
+frame.set("loop.index0", t_12);
+frame.set("loop.revindex", t_13 - t_12);
+frame.set("loop.revindex0", t_13 - t_12 - 1);
+frame.set("loop.first", t_12 === 0);
+frame.set("loop.last", t_12 === t_13 - 1);
+frame.set("loop.length", t_13);
+output += "\n            ";
+if(runtime.inOperator(t_15,["name","url","email"])) {
+output += "\n            ";
+;
+}
+else {
+output += "\n                <div class=\"field\">\n                    ";
+output += runtime.suppressValue(env.getFilter("title").call(context, t_15), env.opts.autoescape);
+output += ": <span>";
+output += runtime.suppressValue(t_16, env.opts.autoescape);
+output += "</span>\n                </div>\n            ";
+;
+}
+output += "\n        ";
+;
+}
+} else {
+t_12 = -1;
+var t_13 = runtime.keys(t_14).length;
+for(var t_17 in t_14) {
+t_12++;
+var t_18 = t_14[t_17];
+frame.set("key", t_17);
+frame.set("value", t_18);
+frame.set("loop.index", t_12 + 1);
+frame.set("loop.index0", t_12);
+frame.set("loop.revindex", t_13 - t_12);
+frame.set("loop.revindex0", t_13 - t_12 - 1);
+frame.set("loop.first", t_12 === 0);
+frame.set("loop.last", t_12 === t_13 - 1);
+frame.set("loop.length", t_13);
+output += "\n            ";
+if(runtime.inOperator(t_17,["name","url","email"])) {
+output += "\n            ";
+;
+}
+else {
+output += "\n                <div class=\"field\">\n                    ";
+output += runtime.suppressValue(env.getFilter("title").call(context, t_17), env.opts.autoescape);
+output += ": <span>";
+output += runtime.suppressValue(t_18, env.opts.autoescape);
+output += "</span>\n                </div>\n            ";
+;
+}
+output += "\n        ";
+;
+}
+}
+}
+frame = frame.pop();
+output += "\n    </div>\n\n\n    <div class=\"body\">\n        ";
+output += runtime.suppressValue(env.getFilter("safe").call(context, runtime.contextOrFrameLookup(context, frame, "detail")), env.opts.autoescape);
+output += "\n    </div>\n\n</article>";
+cb(null, output);
+;
+} catch (e) {
+  cb(runtime.handleError(e, lineno, colno));
+}
+}
+return {
+b_endhead: b_endhead,
+b_main: b_main,
+root: root
+};
+
+})();
+})();
+

--- a/hyde/layout/base.j2
+++ b/hyde/layout/base.j2
@@ -36,24 +36,22 @@
   <link rel="stylesheet" href="{{ media_url('css/font.css') }}">
   <link rel="stylesheet" href="{{ media_url('css/site.css') }}">
   {% endblock css %}
-
   {% block headjs %}
-  
   {% endblock headjs %}
   {% block endhead %}{% endblock endhead %}
 </head>
 <body id="{{ resource.meta.id if resource.meta.id else resource.slug }}">
   {% block content %}
+  <header>
+    <div class="in">
+      <div id="logo"><a href="/"><i class="i-pyjobslogo"></i></a></div>
+      <div id="title"><a href="/">The Free <span>Python Job Board</span></a></div>
+      <div class="sub">for the global Python community</div>
+    </div>
+  </header>
   <div id="container">
       {% block container %}
       <div id="main" role="main">
-          <header>
-            <div class="in">
-              <div id="logo"><a href="/"><i class="i-pyjobslogo"></i></a></div>
-              <div id="title"><a href="/">The Free <span>Python Job Board</span></a></div>
-              <div class="sub">for the global Python community</div>
-            </div>
-          </header>
           {% block below_header %}
             <section id="content">
             {% block main %}

--- a/hyde/layout/editor.j2
+++ b/hyde/layout/editor.j2
@@ -42,6 +42,25 @@
 	        }
 	    };
 	}
+	if (!Array.prototype.find) {
+	Object.defineProperty(Array.prototype, 'find', {
+		value: function(predicate) {
+		  const o = Object(this);
+		  const len = o.length >>> 0;
+		  let k = 0;
+		  while (k < len) {
+		    var kValue = o[k];
+		    if (predicate(kValue)) {
+		      return kValue;
+		    }
+		    k++;
+		  }
+		  return undefined;
+		},
+		configurable: false,
+		writable: false
+		});
+	}
 
 	function get_ad_parts(text){
 		let parts = (('\n' + text).split("\n---\n"));
@@ -79,7 +98,7 @@
 			);
 		check(meta.created || meta.created.getFullYear, /^\s*created:/, "created must be provided and be a valid date");
 		check(meta.created < new Date(), /^\s*created:/, "created date must not be in the future");
-		check(!(meta.tags || []).find((x)=>(x||'').match(/index/i)), /^\s*tags:/, "Tags cannot contain index");
+		check(!(meta.tags || []).find(function(x){ return (x||'').match(/index/i);}), /^\s*tags:/, "Tags cannot contain index");
 	}
 
 	function frontmatter_lint(text) {
@@ -169,7 +188,7 @@
 			let md_converter = new showdown.Converter({noHeaderId: true});
 			const detail = md_converter.makeHtml(parts.body);
 			var html = nunjucks.render("job.j2", {
-				content_url: ()=>'',
+				content_url: function() { return '';},
 				resource: parts,
 				detail: detail
 			});

--- a/hyde/layout/editor.j2
+++ b/hyde/layout/editor.j2
@@ -164,8 +164,8 @@
 		try{
 			let parts = get_ad_parts(full_text);
 			parts.meta = jsyaml.load(parts.meta);
-			let c = parts.meta.created;
-			parts.meta.created = {strftime: function(){return c;}};
+			let c = dayjs(parts.meta.created);
+			parts.meta.created = {strftime: function(){return c.format("dddd, D MMMM YYYY");}};
 			let md_converter = new showdown.Converter({noHeaderId: true});
 			const detail = md_converter.makeHtml(parts.body);
 			var html = nunjucks.render("job.j2", {

--- a/hyde/layout/editor.j2
+++ b/hyde/layout/editor.j2
@@ -1,0 +1,239 @@
+{% extends "base.j2" %}
+{% block scripts %}
+    <script src="//cdnjs.cloudflare.com/ajax/libs/showdown/1.8.6/showdown.min.js"></script>
+
+    <!-- CodeMirror -->
+    <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.37.0/codemirror.min.js"></script>
+	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.37.0/codemirror.min.css">
+
+	<!-- CodeMirror: Addons -->
+	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.37.0/addon/lint/lint.min.css">
+	<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.37.0/addon/lint/lint.min.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/js-yaml/3.11.0/js-yaml.min.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.37.0/addon/mode/overlay.min.js"></script>
+
+	<!-- CodeMirror: Modes -->
+	<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.37.0/mode/markdown/markdown.min.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.37.0/mode/gfm/gfm.min.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.37.0/mode/yaml/yaml.min.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.37.0/mode/yaml-frontmatter/yaml-frontmatter.min.js"></script>
+
+	<!-- Template for preview -->
+	<script src="//mozilla.github.io/nunjucks/files/nunjucks-slim.js"></script>
+	<script src="//unpkg.com/dayjs@1.5.12/dist/dayjs.min.js"></script>
+	<script src="{{ media_url('js/job-preview.js') }}"></script>
+
+	<script>
+	'use strict';
+
+	if (!String.prototype.padStart) {
+	    String.prototype.padStart = function padStart(targetLength,padString) {
+	        targetLength = targetLength>>0; //truncate if number or convert non-number to 0;
+	        padString = String((typeof padString !== 'undefined' ? padString : ' '));
+	        if (this.length > targetLength) {
+	            return String(this);
+	        }
+	        else {
+	            targetLength = targetLength-this.length;
+	            if (targetLength > padString.length) {
+	                padString += padString.repeat(targetLength/padString.length); //append to original to ensure we are longer than needed
+	            }
+	            return padString.slice(0,targetLength) + String(this);
+	        }
+	    };
+	}
+
+	function get_ad_parts(text){
+		let parts = (('\n' + text).split("\n---\n"));
+		return {meta: parts[1], body: parts[2]};
+	};
+
+	function meta_checks(full_text, errors, meta){
+		const text_lines = full_text.split('\n');
+		const loc = CodeMirror.Pos(0,0);
+		function check(pass, line_finder, msg){
+			if (!pass){
+				let error_loc = loc;
+				for (let line=0; line < text_lines.length; ++line) {
+					if (text_lines[line].match(line_finder)) {
+						error_loc = CodeMirror.Pos(line+1, 0);
+					}
+				}
+				errors.push({from: error_loc, to: error_loc, message: msg});
+			}
+		}
+		check((meta.title || '').length > 2, /^\s*title:/, "title must be provided");
+		check((meta.company || '').length > 1, /^\s*company:/, "company must be provided");
+		check((meta.location || '').length > 2, /^\s*location:/, "location must be provided");
+		check(meta.contact, "contact", "Must provide contact info");
+		meta.contact = meta.contact || {};
+		check((meta.contact.name || '').length > 2, /^\s*name:/, "contact.name must be provided");
+		check(
+			(meta.contact.email || '').match(/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,10}$/i),
+			/^\s*email:/,
+			"valid contact.email must be provided")
+		check(
+			(meta.contract || '').match(/(contract|perm|temp|part\-time|other)/i),
+			/^\s*contract:/,
+			"contract must be one of contract, perm, temp, part-time or other"
+			);
+		check(meta.created || meta.created.getFullYear, /^\s*created:/, "created must be provided and be a valid date");
+		check(meta.created < new Date(), /^\s*created:/, "created date must not be in the future");
+		check(!(meta.tags || []).find((x)=>(x||'').match(/index/i)), /^\s*tags:/, "Tags cannot contain index");
+	}
+
+	function frontmatter_lint(text) {
+		const beginning = CodeMirror.Pos(0,0);
+	 	var found = [];
+	 	if (!text.match(/^---\n/)) {
+	 		found.push({from: beginning, to: beginning, message: "Must start with '---' on first line"});
+	 	}
+	 	const parts = get_ad_parts(text);
+	 	let meta;
+	 	try {
+	 		meta = jsyaml.load(parts.meta);
+	 	} catch(e) {
+	     	var loc = e.mark,
+	     		// Offset by 1 because of leading '---' line
+	        	from = loc ? CodeMirror.Pos(loc.line+1, loc.column) : CodeMirror.Pos(1, 0),
+	         	to = from;
+	      	found.push({ from: from, to: to, message: e.message });
+	  	}
+	  	if(!parts.body) {
+	 		found.push({from: beginning, to: beginning, message: "Format should be:\n---\nyaml header\n---\nmarkdown body"});
+	  	}
+	  	if(meta && meta != 'undefined') {
+	  		meta_checks(parts.meta, found, meta);
+	  	}
+	 	return found;
+	}
+
+	function reset_saved() {
+		window.localStorage.currentJobEditorText = ''
+		window.location.reload(true);
+	}
+
+	$("#pr-link").click(function(e) {
+		const full_text = window.meta_codemirror.getValue();
+		if (frontmatter_lint(full_text).length) {
+			if (!confirm("There are errors in this document, really continue?")){
+				e.preventDefault();
+				e.stopPropagation();
+				return false;
+			}
+		}
+	});
+
+	function iso_date() {
+		const today = new Date();
+		const month_str = ('' + (today.getMonth()+1)).padStart(2, '0');
+		const day_str = ('' + today.getDate()).padStart(2, '0');
+		return '' + today.getFullYear() + '-' + month_str + '-' + day_str;
+	}
+
+	function slugify(text)
+	{
+	  return text.toString().toLowerCase()
+	    .replace(/\s+/g, '-')           // Replace spaces with -
+	    .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
+	    .replace(/\-\-+/g, '-')         // Replace multiple - with single -
+	    .replace(/^-+/, '')             // Trim - from start of text
+	    .replace(/-+$/, '');            // Trim - from end of text
+	}
+
+	let cur_update_id = null;
+	function queue_preview_update() {
+		window.localStorage.currentJobEditorText = window.meta_codemirror.getValue();
+		if(cur_update_id) {
+			window.clearTimeout(cur_update_id);
+			cur_update_id = null;
+		}
+		cur_update_id = window.setTimeout(update_preview, 200);
+	}
+
+	function update_pr_link(full_text, meta) {
+		const base = "https://github.com/pythonjobs/jobs/new/master/jobs?";
+		const filename = slugify('' + meta.company + ' ' + meta.title) + ".html";
+		const query_params = $.param({filename: filename, value: full_text});
+		$("#pr-link").attr('href', base + query_params);
+	};
+
+	function update_preview() {
+		$("#preview").html("loading");
+		const full_text = window.meta_codemirror.getValue();
+		try{
+			let parts = get_ad_parts(full_text);
+			parts.meta = jsyaml.load(parts.meta);
+			let c = parts.meta.created;
+			parts.meta.created = {strftime: function(){return c;}};
+			let md_converter = new showdown.Converter({noHeaderId: true});
+			const detail = md_converter.makeHtml(parts.body);
+			var html = nunjucks.render("job.j2", {
+				content_url: ()=>'',
+				resource: parts,
+				detail: detail
+			});
+			$("#preview").html(html);
+			update_pr_link(full_text, parts.meta);
+		}catch(e){
+			console.log(e);
+			$("#preview").html("<b>Error generating preview</b>");
+			return;
+		}
+	}
+
+	$(function(){
+		const ad_editor = document.getElementById("ad-editor");
+		ad_editor.value = ad_editor.value.replace(
+			/!!timestamp 'XXX'/,
+			"!!timestamp " + iso_date()
+		);
+		window.meta_codemirror = CodeMirror.fromTextArea(ad_editor, {
+			mode: 'yaml-frontmatter',
+			lineWrapping: true,
+			lineNumbers: true,
+			lint: {getAnnotations: frontmatter_lint},
+			gutters: ["CodeMirror-lint-markers"],
+			viewportMargin: Infinity
+		});
+		window.meta_codemirror.on('changes', queue_preview_update);
+		if (localStorage.currentJobEditorText) {
+			window.meta_codemirror.setValue(localStorage.currentJobEditorText);
+		}
+		update_preview()
+	});
+	</script>
+{% endblock %}
+
+{%block css %}
+{{ super() }}
+<link href="//fonts.googleapis.com/css?family=Source+Code+Pro:400,700" rel="stylesheet">
+<link rel="stylesheet" href="{{ media_url('css/editor.css') }}">
+{%endblock %}
+
+{% block container %}
+<div id=editor-column>
+	<h2>Editor</h2>
+	<div class=infopanel>
+		<p>Fill in the template below.  The preview should auto-update to reflect changes.</p>
+		<p><em><b>Please note:</b> The preview may not be 100% identical to the final output,
+			we use a different rendering engine for the live site.</em></p>
+		<p>Once you're happy with the result, press 'Create pull request' below.<br/>
+		<em>It helps if you're logged into github already before clicking that button (bug with github).</em><br/>
+		If the button doesn't work, please copy-paste the <b>editor</b> text as a new file in a Github pull request here:
+		<a target=_blank href="https://github.com/pythonjobs/jobs/new/master/jobs?filename=.html&value=paste%20here...">https://github.com/pythonjobs/jobs/new/master/jobs</a>
+		</p>
+	</div>
+	<div id=editor-buttons>
+		<button onclick=reset_saved()>Reset to template</button>
+		<a id=pr-link target=_blank>Create Pull Request</a>
+	</div>
+	<div id=editors>
+		<textarea id=ad-editor>{% include "example.md" %}</textarea>
+	</div>
+</div>
+<div id=preview-column>
+<h2>Preview</h2>
+<div id=preview></div>
+</div>
+{% endblock %}

--- a/hyde/layout/example.md
+++ b/hyde/layout/example.md
@@ -1,0 +1,25 @@
+---
+title: # Job Advert Title (required)
+company: # Your Company (required)
+url: https://... #<Link to your site/a job spec (optional)>
+location: # where is the job based? e.g. London,England
+          # Choose one of the following options
+contract: # permanent / contract / part-time / temporary
+contact:
+    name: # Your name (required)
+    email: # Email address applicants should submit to (required)
+    phone: # Phone number (optional)
+    # <additional contact fields>: <additional value>
+created: !!timestamp 2018-04-25
+tags:
+  - python
+  - sql
+  - django
+  # include relevant tags
+---
+
+# Title
+More information about the role...
+
+## Sub-title
+Further info

--- a/hyde/layout/job.j2
+++ b/hyde/layout/job.j2
@@ -1,5 +1,4 @@
 {% extends "base.j2" %}
-{% from "macros.j2" import render_excerpt with context  %}
 
 {%  block endhead %}
     <meta property="og:site_name" content="The Free Python Job Board"/>


### PR DESCRIPTION
@salimfadhley / @lordmauve  thoughts?

![2018-04-25 17 29 56](https://user-images.githubusercontent.com/704526/39260357-230b497c-48b1-11e8-9272-153285ec75f3.gif)

Change the main site layout to use flex-flow for putting the footer at the bottom of the page.  This doesn't work in IE11, but just means that the footer floats up a bit on short pages (we don't have many)
Also update map button styling, because google changed the look-and-feel of their buttons

the preview template is (largely) auto generated from the job.j2 jinja template by using nunjucks(https://mozilla.github.io/nunjucks/) with some minor tweaks.
Editor code is pretty quick-and-dirty, but seems to work well in chrome.
Also direct linking to pre-filled github PR, including filename generation (it's just a slug, so might collide with existing)
Inline real-time checks of the meta (to complement, not replace the PR tests)
